### PR TITLE
simply package info for .conda files

### DIFF
--- a/conda_package_handling/conda_fmt.py
+++ b/conda_package_handling/conda_fmt.py
@@ -29,15 +29,12 @@ def _lookup_component_filename(zf, file_id, component_name):
                             _.startswith(component_filename_without_ext)]
     return component_filename
 
+
 def _extract_component(fn, file_id, component_name, dest_dir=None):
     with TemporaryDirectory() as tmp:
         with utils.tmp_chdir(tmp):
             with zipfile.ZipFile(fn, compression=zipfile.ZIP_STORED) as zf:
-                component_filename = _lookup_component_filename(zf, file_id, component_name)
-                if not component_filename:
-                    raise RuntimeError("didn't find {} in {}".format(
-                        component_filename_without_ext, fn))
-                component_filename = component_filename[0]
+                component_filename = _lookup_component_filename(zf, file_id, component_name)[0]
                 zf.extract(component_filename)
                 _tar_xf(component_filename, dest_dir)
 
@@ -90,19 +87,11 @@ class CondaFormat_v2(AbstractBaseFormat):
 
     @staticmethod
     def get_pkg_details(in_file):
-        # the thing of interest with the new format is the inner pkg-* file, not the package as a whole.
-        file_id = os.path.basename(in_file).replace('.conda', '')
         stat_result = os.lstat(in_file)
         size = stat_result.st_size
-        with zipfile.ZipFile(in_file, compression=zipfile.ZIP_STORED) as zf:
-            component_filename = _lookup_component_filename(zf, file_id, 'pkg')
-            if not component_filename:
-                raise RuntimeError("didn't find {} in {}".format(
-                    component_filename_without_ext, in_file))
-            else:
-                component_filename = component_filename[0]
-            pkg_file = zf.open(component_filename, 'r')
-            inner_sha256 = utils.sha256_checksum(pkg_file)
-        with open(in_file, 'rb') as fd:
-            outer_sha256 = utils.sha256_checksum(fd)
-        return {"size": size, "inner_sha256": inner_sha256, "outer_sha256": outer_sha256}
+        # open the file twice because we need to start from the beginning each time
+        with open(in_file, 'rb') as f:
+            md5 = utils.md5_checksum(f)
+        with open(in_file, 'rb') as f:
+            sha256 = utils.sha256_checksum(f)
+        return {"size": size, "md5": md5, "sha256": sha256}

--- a/news/simplify_conda_pkg_info
+++ b/news/simplify_conda_pkg_info
@@ -1,0 +1,25 @@
+Enhancements:
+-------------
+
+* <news item>
+
+Bug fixes:
+----------
+
+* simplify .conda package info, to work with conda/conda#8639 and conda/conda-build#3500
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* <news item>
+

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -20,12 +20,13 @@ def test_api_tarball_details(testing_workdir):
     assert results["md5"] == "0f9cce120a73803a70abb14bd4d4900b"
     assert results["sha256"] == "34c659b0fdc53d28ae721fd5717446fb8abebb1016794bd61e25937853f4c29c"
 
+
 def test_api_conda_v2_details(testing_workdir):
     condafile = os.path.join(data_dir, test_package_name + '.conda')
     results = api.get_pkg_details(condafile)
     assert results["size"] == 113421
-    assert results["inner_sha256"] == "c9c3042f7ce1c304a5aa4baa0bfd1b23e0fbb16e17e203fd3a16ade20beb5ee5"
-    assert results["outer_sha256"] == "181ec44eb7b06ebb833eae845bcc466ad96474be1f33ee55cab7ac1b0fdbbfa3"
+    assert results["sha256"] == "181ec44eb7b06ebb833eae845bcc466ad96474be1f33ee55cab7ac1b0fdbbfa3"
+    assert results["md5"] == "23c226430e35a3bd994db6c36b9ac8ae"
 
 
 def test_api_extract_tarball_explicit_path(testing_workdir):


### PR DESCRIPTION
This goes with https://github.com/conda/conda/pull/8639/ and https://github.com/conda/conda-build/pull/3500

In those PR's, we move the new .conda format to its own key in repodata, ``packages.conda``.  That allows us to use the same keys (size, md5, sha256) for either file type.

We also ditch the inner sha256 here, because that's really for package signing, and the inner sha256 doesn't add anything there.