### PR TITLE
fix strange path overlaps on Windows

### DIFF
--- a/conda_package_handling/tarball.py
+++ b/conda_package_handling/tarball.py
@@ -98,15 +98,16 @@ class CondaTarBZ2(AbstractBaseFormat):
     def create(prefix, file_list, out_fn, out_folder=os.getcwd(), **kw):
         with TemporaryDirectory() as tmpdir:
             out_file = create_compressed_tarball(prefix, file_list, tmpdir,
-                                                 out_fn.replace('.tar.bz2', ''),
+                                                 os.path.basename(out_fn).replace('.tar.bz2', ''),
                                                  '.tar.bz2', 'bzip2')
             final_path = os.path.join(out_folder, os.path.basename(out_file))
-            try:
-                shutil.move(out_file, final_path)
-            except OSError as e:
-                logging.getLogger(__name__).info("Moving temporary"
-                    "package from {} to {} had some issues.  Error "
-                    "message was: {}".format(out_file, final_path, repr(e)))
+            if out_file != final_path:
+                try:
+                    shutil.move(out_file, final_path)
+                except OSError as e:
+                    logging.getLogger(__name__).info("Moving temporary "
+                        "package from {} to {} had some issues.  Error "
+                        "message was: {}".format(out_file, final_path, repr(e)))
         return final_path
 
     @staticmethod


### PR DESCRIPTION
https://ci.appveyor.com/project/ContinuumAnalyticsFOSS/conda-build/builds/24546103/job/ldw184ysl3bca1um#L3926

I'm pretty sure the problem is that the "out_fn" is being passed in as an absolute path, which when joined with tmpdir becomes just the value of "out_fn"

```
>>> os.path.join('/Users/msarahan/code', '/Users/msarahan/Downloads')
'/Users/msarahan/Downloads'
```

<!---
Thanks for opening a PR on conda-package-handling!
 Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html
 If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
 Thanks again!
-->
