### PR TITLE
add exception

### DIFF
--- a/src/conda_package_handling/api.py
+++ b/src/conda_package_handling/api.py
@@ -1,11 +1,13 @@
 import os as _os
 
+from libarchive.exception import ArchiveError as _LibarchiveArchiveError
 from six import string_types as _string_types
 import tqdm
 
 from .tarball import CondaTarBZ2 as _CondaTarBZ2
 from .conda_fmt import CondaFormat_v2 as _CondaFormat_v2
 from .utils import TemporaryDirectory as _TemporaryDirectory
+from .exceptions import InvalidArchiveError
 
 SUPPORTED_EXTENSIONS = {'.tar.bz2': _CondaTarBZ2,
                         '.conda': _CondaFormat_v2}
@@ -43,7 +45,10 @@ def extract(fn, dest_dir=None, components=None):
         dest_dir = get_default_extracted_folder(fn)
     for ext in SUPPORTED_EXTENSIONS:
         if fn.endswith(ext):
-            SUPPORTED_EXTENSIONS[ext].extract(fn, dest_dir, components=components)
+            try:
+                SUPPORTED_EXTENSIONS[ext].extract(fn, dest_dir, components=components)
+            except _LibarchiveArchiveError as e:
+                raise InvalidArchiveError(fn, str(e))
             break
     else:
         raise ValueError("Didn't recognize extension for file '{}'.  Supported extensions are: {}"

--- a/src/conda_package_handling/exceptions.py
+++ b/src/conda_package_handling/exceptions.py
@@ -1,0 +1,9 @@
+from errno import ENOENT
+
+class InvalidArchiveError(Exception):
+    """Raised when libarchive can't open a file"""
+    def __init__(self, fn, msg, *args, **kw):
+        msg = ("Error with archive %s.  You probably need to delete and re-download "
+               "or re-create this file.  Message from libarchive was:\n\n%s" % (fn, msg))
+        self.errno = ENOENT
+        super(InvalidArchiveError, self).__init__(msg)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -157,5 +157,5 @@ def tests_secure_refusal_to_extract_dotdot(testing_workdir):
         open('thebrain', 'w').close()
         tf.add(os.path.join(testing_workdir, 'thebrain'), '../naughty/abs_path')
 
-    with pytest.raises(libarchive.exception.ArchiveError):
+    with pytest.raises(api.InvalidArchiveError):
         api.extract('pinkie.tar.bz2')


### PR DESCRIPTION
so that clients don't need to import libarchive directly to handle its exceptions

