### PR TITLE
remove tempfile renaming.  Write directly.

### DIFF
--- a/src/conda_package_handling/conda_fmt.py
+++ b/src/conda_package_handling/conda_fmt.py
@@ -71,14 +71,12 @@ class CondaFormat_v2(AbstractBaseFormat):
 
         pkg_metadata = {'conda_pkg_format_version': CONDA_PACKAGE_FORMAT_VERSION}
 
-        with zipfile.ZipFile(conda_pkg_fn + ".c~", 'w', compression=zipfile.ZIP_STORED) as zf:
+        with zipfile.ZipFile(conda_pkg_fn, 'w', compression=zipfile.ZIP_STORED) as zf:
             with NamedTemporaryFile(mode='w', delete=False) as tf:
                 json.dump(pkg_metadata, tf)
                 zf.write(tf.name, 'metadata.json')
             for pkg in (info_tarball, pkg_tarball):
                 zf.write(pkg, os.path.basename(pkg))
-
-        os.rename(conda_pkg_fn + ".c~", conda_pkg_fn)
 
         utils.rm_rf(tf.name)
         utils.rm_rf(info_tarball)

--- a/src/conda_package_handling/tarball.py
+++ b/src/conda_package_handling/tarball.py
@@ -95,10 +95,7 @@ class CondaTarBZ2(AbstractBaseFormat):
             out_folder = os.path.dirname(out_fn)
         out_file = create_compressed_tarball(prefix, file_list, out_folder,
                                              os.path.basename(out_fn).replace('.tar.bz2', ''),
-                                             '.tar.bz2.c~', 'bzip2')
-        # we output to .c~ to avoid clobbering existing good files until we know we
-        #    have a finished file
-        os.rename(out_file, out_file.replace('.c~', ''))
+                                             '.tar.bz2', 'bzip2')
         return out_file
 
     @staticmethod


### PR DESCRIPTION
<!---
Thanks for opening a PR on conda-package-handling!
 Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html
 If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
 Thanks again!
-->
Still seeing obnoxious permission errors on CI.  Let's try just getting rid of the temporary files and write straight to the real output file path.