### PR TITLE
default tempdir location to nested in cwd, add back some tempdir usage

### DIFF
--- a/src/conda_package_handling/utils.py
+++ b/src/conda_package_handling/utils.py
@@ -295,7 +295,7 @@ class TemporaryDirectory(object):
     name = None
     _closed = False
 
-    def __init__(self, suffix="", prefix='tmp', dir=None):
+    def __init__(self, suffix="", prefix='.cph_tmp', dir=os.getcwd()):
         self.name = mkdtemp(suffix, prefix, dir)
 
     def __repr__(self):


### PR DESCRIPTION
This sets the default dir for TemporaryDirectory to cwd.  This hopefully avoids the permissions problems we've been seeing with appveyor and azure, I think because they're split across two filesystems.

This also cleans up the temporary .zst files, which in 1.3.8 were being left around, making a mess.
