### PR TITLE
add a verification step in conversion.  Match file presence and size

### DIFF
--- a/src/conda_package_handling/exceptions.py
+++ b/src/conda_package_handling/exceptions.py
@@ -29,3 +29,17 @@ class CaseInsensitiveFileSystemError(Exception):
             extract_location=extract_location,
             **kwargs
         )
+
+
+class ConversionError(Exception):
+    def __init__(self, missing_files, mismatching_sizes, *args, **kw):
+        self.missing_files = missing_files
+        self.mismatching_sizes = mismatching_sizes
+        super(ConversionError, self).__init__(msg)
+
+    def __str__(self):
+        errors = ""
+        errors = "Missing files in converted package: %s\n" % self.missing_files
+        errors = (errors + "Mismatching sizes (corruption) in converted package: %s" %
+                  self.mismatching_sizes)
+        return errors

--- a/src/conda_package_handling/utils.py
+++ b/src/conda_package_handling/utils.py
@@ -32,9 +32,7 @@ def make_writable(path):
         mode = os.lstat(path).st_mode
         if S_ISDIR(mode):
             os.chmod(path, S_IMODE(mode) | S_IWRITE | S_IEXEC)
-        elif islink(path):
-            os.lchmod(path, S_IMODE(mode) | S_IWRITE)
-        elif S_ISREG(mode):
+        elif S_ISREG(mode) or islink(path):
             os.chmod(path, S_IMODE(mode) | S_IWRITE)
         else:
             log.debug("path cannot be made writable: %s", path)

--- a/src/conda_package_handling/validate.py
+++ b/src/conda_package_handling/validate.py
@@ -1,4 +1,29 @@
-def folder_has_conda_metadata(folder):
-    """If folders don't have conda metadata in them, we can still bundle them, but conda won't
-    know what to do with the product."""
-    raise NotImplementedError
+import os
+from .utils import TemporaryDirectory
+
+
+def validate_converted_files_match(src_file_or_folder, subject, reference_ext=""):
+    from .api import extract
+    with TemporaryDirectory() as tmpdir:
+        if os.path.isdir(src_file_or_folder):
+            src_folder = src_file_or_folder
+        else:
+            extract(src_file_or_folder + reference_ext,
+                    dest_dir=os.path.join(tmpdir, 'src'))
+            src_folder = os.path.join(tmpdir, 'src')
+
+        converted_folder = os.path.join(tmpdir, 'converted')
+        extract(subject, dest_dir=converted_folder)
+
+        missing_files = set()
+        mismatch_size = set()
+        for root, dirs, files in os.walk(src_folder):
+            for f in files:
+                absfile = os.path.join(root, f)
+                rp = os.path.relpath(absfile, src_folder)
+                destpath = os.path.join(converted_folder, rp)
+                if not os.path.isfile(destpath):
+                    missing_files.add(rp)
+                elif os.stat(absfile).st_size != os.stat(destpath).st_size:
+                    mismatch_size.add(rp)
+    return src_file_or_folder, missing_files, mismatch_size


### PR DESCRIPTION
<!---
Thanks for opening a PR on conda-package-handling!
 Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html
 If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
 Thanks again!
-->

This still needs a test.  We've seen some corrupt files from earlier iterations of CPH.  This should help us test files and also make sure we don't release further corrupt files.
