### PR TITLE
fix zipfile exception incompat with py2, extend timebomb on refusal t…

### DIFF
--- a/news/py27
+++ b/news/py27
@@ -6,7 +6,7 @@ Enhancements:
 Bug fixes:
 ----------
 
-* <news item>
+* fix BadZipFile exception handling on py27
 
 Deprecations:
 -------------

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -143,7 +143,7 @@ def test_create_package_with_uncommon_conditions_captures_all_content(testing_wo
             assert stat.st_nlink == 1
 
 
-@pytest.mark.skipif(datetime.now() <= datetime(2019, 7, 1), reason="Don't understand why this doesn't behave.  Punt.")
+@pytest.mark.skipif(datetime.now() <= datetime(2019, 9, 1), reason="Don't understand why this doesn't behave.  Punt.")
 def test_secure_refusal_to_extract_abs_paths(testing_workdir):
     with tarfile.open('pinkie.tar.bz2', 'w:bz2') as tf:
         open('thebrain', 'w').close()


### PR DESCRIPTION
…o extract abs path test

<!---
Thanks for opening a PR on conda-package-handling!
 Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html
 If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
 Thanks again!
-->
