### PR TITLE
Handle incomplete archives correctly

### DIFF
--- a/news/fix_null_pointer
+++ b/news/fix_null_pointer
@@ -1,0 +1,4 @@
+Bug fixes:
+----------
+
+* Avoid segfaulting on incomplete archives

--- a/src/conda_package_handling/archive_utils_c.c
+++ b/src/conda_package_handling/archive_utils_c.c
@@ -142,7 +142,7 @@ static int extract_file_c(const char *filename, const char **err_str) {
     int r;
 
     if (!err_str) {
-        return NULL;
+        return 0;
     }
     /* attributes we want to restore. */
     flags = ARCHIVE_EXTRACT_TIME;

--- a/src/conda_package_handling/archive_utils_c.c
+++ b/src/conda_package_handling/archive_utils_c.c
@@ -180,6 +180,9 @@ static int extract_file_c(const char *filename, const char **err_str) {
             r = copy_data(a, ext);
             if (r < ARCHIVE_WARN) {
                 *err_str = archive_error_string(ext);
+                if (*err_str == NULL) {
+                  *err_str = archive_error_string(a);
+                }
                 return 1;
             }
         }

--- a/src/conda_package_handling/archive_utils_cy.pyx
+++ b/src/conda_package_handling/archive_utils_cy.pyx
@@ -16,6 +16,7 @@ def extract_file(tarball):
     cdef const char *err_str = NULL
     result = extract_file_c(tarball, &err_str)
     if result:
+        assert err_str != NULL
         return 1, <bytes> err_str
     return 0, b''
 


### PR DESCRIPTION
In `copy_data`, the error could also come from the reader and not just from the writer. Check for this case to avoid returning a NULL error string.

Fixes https://github.com/conda/conda/issues/9414