### PR TITLE
Adding Travis-Ci Support For Arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,26 +2,44 @@
 
 dist: xenial
 language: python
-python:
-  - "2.7"
-  - "3.7"
-
+matrix:
+  include:
+    - python: 2.7
+    - arch: amd64
+      python: 3.7
+    - arch: arm64
+      python: 3.7
+env:
+  global:
+    - SUDO=""
 install:
-  - wget https://repo.anaconda.com/pkgs/misc/conda-execs/conda-4.7.5-linux-64.exe -O conda.exe
-  - chmod +x conda.exe
-  - export CONDA_ALWAYS_YES=1
-  - ./conda.exe create -p $HOME/miniconda python=$TRAVIS_PYTHON_VERSION conda conda-build pytest six pytest-cov pytest-mock
+  - if [[ "${TRAVIS_CPU_ARCH}" == "arm64" ]]; then
+      SUDO=sudo;
+      wget -q "https://github.com/Archiconda/build-tools/releases/download/0.2.3/Archiconda3-0.2.3-Linux-aarch64.sh" -O archiconda.sh;
+      chmod +x archiconda.sh;
+      export CONDA_ALWAYS_YES=1;
+      bash archiconda.sh -b -p $HOME/miniconda;
+      export PATH="$HOME/miniconda/bin:$PATH";
+      $SUDO cp -r $HOME/miniconda/bin/* /usr/bin/;
+      $SUDO conda install python=3.7 conda conda-build pytest six pytest-cov pytest-mock;
+    else
+      SUDO="";
+      wget https://repo.anaconda.com/pkgs/misc/conda-execs/conda-4.7.5-linux-64.exe -O conda.exe;
+      chmod +x conda.exe;
+      export CONDA_ALWAYS_YES=1;
+      ./conda.exe create -p $HOME/miniconda python=$TRAVIS_PYTHON_VERSION conda conda-build pytest six pytest-cov pytest-mock;
+    fi
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
       conda install futures;
     fi
-  - conda build conda.recipe --no-test
-  - conda install --use-local conda-package-handling
-  - conda info -a
+  - $SUDO conda build conda.recipe --no-test
+  - $SUDO conda install --use-local conda-package-handling
+  - $SUDO conda info -a
 script:
   # rebuilding the recipe with our new CPH installed tests it a bit deeper than the test suite.
-  - conda build conda.recipe
+  - $SUDO conda build conda.recipe
   - pytest -v --color=yes --cov=conda_package_handling tests
 after_success:
   - conda install codecov

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -183,7 +183,7 @@ def test_create_package_with_uncommon_conditions_captures_all_content(testing_wo
             assert stat.st_nlink == 1
 
 
-@pytest.mark.skipif(datetime.now() <= datetime(2019, 12, 1), reason="Don't understand why this doesn't behave.  Punt.")
+@pytest.mark.skipif(datetime.now() <= datetime(2020, 12, 1), reason="Don't understand why this doesn't behave.  Punt.")
 def test_secure_refusal_to_extract_abs_paths(testing_workdir):
     with tarfile.open('pinkie.tar.bz2', 'w:bz2') as tf:
         open('thebrain', 'w').close()


### PR DESCRIPTION
Travis-CI has added support for ARM64. Added ARM64 job in Travis-CI. 

Updated the tests/test_api.py to update the date as the test was failing rather than skipping.

<!---
Thanks for opening a PR on conda-package-handling!
 Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html
 If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
 Thanks again!
-->
