### PR TITLE
add component archive hashes to metadata.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
       bash archiconda.sh -b -p $HOME/miniconda;
       export PATH="$HOME/miniconda/bin:$PATH";
       $SUDO cp -r $HOME/miniconda/bin/* /usr/bin/;
-      $SUDO conda install python=3.7 conda conda-build pytest six pytest-cov pytest-mock;
+      $SUDO conda install python=3.7 conda conda-build pytest six pytest-cov pytest-mock=1;
     else
       SUDO="";
       wget https://repo.anaconda.com/pkgs/misc/conda-execs/conda-4.7.5-linux-64.exe -O conda.exe;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ install:
   - set "CONDA_PKGS_DIRS=C:\condacache\pkgs"
   - set "CONDA_ALWAYS_YES=true"
   - set "CONDA_AUTO_UPDATE_CONDA=false"
-  - loner_conda.exe create -p C:\test_conda python=%PYTHON_VERSION% conda conda-build pytest six pytest-cov pytest-mock "conda-package-handling!=1.5.0"
+  - loner_conda.exe create -p C:\test_conda python=%PYTHON_VERSION% conda conda-build pytest six pytest-cov pytest-mock=1 "conda-package-handling!=1.5.0"
   # these correspond to folder naming of miniconda installs on appveyor.  See
   # https://www.appveyor.com/docs/installed-software#python
   - call "C:\test_conda\Scripts\activate.bat"

--- a/src/conda_package_handling/conda_fmt.py
+++ b/src/conda_package_handling/conda_fmt.py
@@ -87,7 +87,8 @@ class CondaFormat_v2(AbstractBaseFormat):
                     zf.write(tf.name, 'metadata.json')
                 for pkg in (info_tarball, pkg_tarball):
                     zf.write(pkg, os.path.basename(pkg))
-                utils.rm_rf(tf.name)
+                if os.path.lexists(tf.name):
+                    utils.rm_rf(tf.name)
         return conda_pkg_fn
 
     @staticmethod

--- a/src/conda_package_handling/utils.py
+++ b/src/conda_package_handling/utils.py
@@ -4,6 +4,7 @@ from errno import ENOENT, EACCES, EPERM, EROFS
 import fnmatch
 import hashlib
 from itertools import chain
+import json
 import logging
 import os
 from os.path import (isdir, isfile, basename, dirname, join, split, lexists, normpath,
@@ -409,3 +410,14 @@ def sha256_checksum(fd):
 
 def md5_checksum(fd):
     return _checksum(fd, 'md5')
+
+
+def json_dumps_compact(obj):
+    return json.dumps(
+        obj,
+        ensure_ascii=True,
+        indent=None,
+        sort_keys=True,
+        separators=(",", ":"),
+        skipkeys=True,
+    )


### PR DESCRIPTION
The root-level metadata.json file will now have the form

```
{
  "conda_pkg_format_version":2,
  "schema_version":1,
  "pkg":{
    "fn":"pkg-fn.tar.zstd",
    "sha256":"1234567890123456789012345678901234567890123456789012345678901234",
    "size":456
  },
  "info":{
    "fn":"info-fn.tar.zstd",
    "sha256":"1234567890123456789012345678901234567890123456789012345678901234",
    "size":123
  }
}
```