### PR TITLE
BUG not all parsers have args.out_folder

### DIFF
--- a/news/out_folder.rst
+++ b/news/out_folder.rst
@@ -1,0 +1,24 @@
+Enhancements:
+-------------
+
+* <news item>
+
+Bug fixes:
+----------
+
+* Fixed bug where extract parser cli failed due to not having ``out_folder`` attribute.
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* <news item>

--- a/src/conda_package_handling/cli.py
+++ b/src/conda_package_handling/cli.py
@@ -73,7 +73,7 @@ def parse_args(parse_this=None):
 
 def main(args=None):
     args = parse_args(args)
-    if args.out_folder:
+    if hasattr(args, "out_folder") and args.out_folder:
         args.out_folder = os.path.abspath(os.path.normpath(os.path.expanduser(args.out_folder))) + os.sep
     if args.subparser_name in ('extract', 'x'):
         if args.info:


### PR DESCRIPTION
This PR fixes #72.