### PR TITLE
Add miscellaneous fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
 script:
   # rebuilding the recipe with our new CPH installed tests it a bit deeper than the test suite.
   - $SUDO conda build conda.recipe
-  - python -m pytest -v --color=yes --cov=conda_package_handling tests
+  - python -m pytest -v --color=yes -rA --cov=conda_package_handling tests
 after_success:
   - conda install codecov
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,35 +12,42 @@ matrix:
 env:
   global:
     - SUDO=""
+    - CONDA_ALWAYS_YES=1
 install:
+  - set -e
   - if [[ "${TRAVIS_CPU_ARCH}" == "arm64" ]]; then
-      SUDO=sudo;
+      set -x;
+      # Archiconda install requires sudo for running commands. Pass the path
+      # through to the sudo environment so that condda is accessible
+      SUDO='sudo env PATH=$PATH'
       wget -q "https://github.com/Archiconda/build-tools/releases/download/0.2.3/Archiconda3-0.2.3-Linux-aarch64.sh" -O archiconda.sh;
       chmod +x archiconda.sh;
-      export CONDA_ALWAYS_YES=1;
       bash archiconda.sh -b -p $HOME/miniconda;
       export PATH="$HOME/miniconda/bin:$PATH";
-      $SUDO cp -r $HOME/miniconda/bin/* /usr/bin/;
-      $SUDO conda install python=3.7 conda conda-build pytest six pytest-cov pytest-mock mock;
+      $SUDO conda install python=3.7 conda conda-build;
+      set +x;
     else
-      SUDO="";
       wget https://repo.anaconda.com/pkgs/misc/conda-execs/conda-4.7.5-linux-64.exe -O conda.exe;
       chmod +x conda.exe;
-      export CONDA_ALWAYS_YES=1;
-      ./conda.exe create -p $HOME/miniconda python=$TRAVIS_PYTHON_VERSION conda conda-build pytest six pytest-cov pytest-mock mock;
-    fi
+      ./conda.exe create -p $HOME/miniconda python=$TRAVIS_PYTHON_VERSION conda conda-build;
+    fi;
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      conda install futures;
-    fi
+      pip install futures mock pytest-cov pytest-mock;
+    else
+      pip3 install mock pytest-cov pytest-mock;
+    fi;
   - $SUDO conda build conda.recipe --no-test
   - $SUDO conda install --use-local conda-package-handling
   - $SUDO conda info -a
 script:
   # rebuilding the recipe with our new CPH installed tests it a bit deeper than the test suite.
+  - which conda
   - $SUDO conda build conda.recipe
-  - python -m pytest -v --color=yes -rA --cov=conda_package_handling tests
+  # the system pytest is used for coverage testing, cph from current conda envorinment is used.
+  - which pytest
+  - pytest -v --color=yes -rA --cov=conda_package_handling tests
 after_success:
-  - conda install codecov
+  - $SUDO conda install codecov
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
 script:
   # rebuilding the recipe with our new CPH installed tests it a bit deeper than the test suite.
   - $SUDO conda build conda.recipe
-  - pytest -v --color=yes --cov=conda_package_handling tests
+  - python -m pytest -v --color=yes --cov=conda_package_handling tests
 after_success:
   - conda install codecov
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,13 @@ install:
       bash archiconda.sh -b -p $HOME/miniconda;
       export PATH="$HOME/miniconda/bin:$PATH";
       $SUDO cp -r $HOME/miniconda/bin/* /usr/bin/;
-      $SUDO conda install python=3.7 conda conda-build pytest six pytest-cov pytest-mock;
+      $SUDO conda install python=3.7 conda conda-build pytest six pytest-cov pytest-mock mock;
     else
       SUDO="";
       wget https://repo.anaconda.com/pkgs/misc/conda-execs/conda-4.7.5-linux-64.exe -O conda.exe;
       chmod +x conda.exe;
       export CONDA_ALWAYS_YES=1;
-      ./conda.exe create -p $HOME/miniconda python=$TRAVIS_PYTHON_VERSION conda conda-build pytest six pytest-cov pytest-mock;
+      ./conda.exe create -p $HOME/miniconda python=$TRAVIS_PYTHON_VERSION conda conda-build pytest six pytest-cov pytest-mock mock;
     fi
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -33,6 +33,7 @@ test:
     - pytest
     - pytest-cov
     - pytest-mock
+    - mock
   imports:
     - conda_package_handling
     - conda_package_handling.archive_utils_cy

--- a/news/miscellaneous_fixes.rst
+++ b/news/miscellaneous_fixes.rst
@@ -9,7 +9,7 @@ Bug fixes:
 * Fix #71, larger directories fail to extract using libarchive
 * When testing that exceptions are raised or archives containing abs paths, first check that such a "broken" archive was created during test setup... otherwise skip the test.
 * api.create now raises an error correctly if archive creation failed or extension is not supported.
-* Travis CI issue now resolved (pytest from outside conda env was being used)
+* Travis CI issue now resolved, mock added as dependency for conda test environments and system dependencies
 
 Deprecations:
 -------------

--- a/news/miscellaneous_fixes.rst
+++ b/news/miscellaneous_fixes.rst
@@ -1,0 +1,28 @@
+Enhancements:
+-------------
+
+* Python tar extraction now used as a fallback if libarchive fails
+
+Bug fixes:
+----------
+
+* Fix #71, larger directories fail to extract using libarchive
+* When testing that exceptions are raised or archives containing abs paths, first check that such a "broken" archive was created during test setup... otherwise skip the test.
+* api.create now raises an error correctly if archive creation failed or extension is not supported.
+* Travis CI issue now resolved (pytest from outside conda env was being used)
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* <news item>
+

--- a/src/conda_package_handling/api.py
+++ b/src/conda_package_handling/api.py
@@ -76,14 +76,21 @@ def create(prefix, file_list, out_fn, out_folder=None, **kw):
         except:
             raise
 
+    out = None
     for ext in SUPPORTED_EXTENSIONS:
         if out_fn.endswith(ext):
             try:
                 out = SUPPORTED_EXTENSIONS[ext].create(prefix, file_list, out_fn, out_folder, **kw)
-            except:
+                break
+            except Exception as err:
                 # don't leave broken files around
-                if _os.path.isfile(out):
+                if out and _os.path.isfile(out):
                     _rm_rf(out)
+                raise err
+    else:
+        raise ValueError("Didn't recognize extension for file '{}'.  Supported extensions are: {}"
+                         .format(fn, list(SUPPORTED_EXTENSIONS.keys())))
+
     return out
 
 

--- a/src/conda_package_handling/archive_utils_c.c
+++ b/src/conda_package_handling/archive_utils_c.c
@@ -134,7 +134,7 @@ static int copy_data(struct archive *ar, struct archive *aw)
             return (ARCHIVE_OK);
         if (r < ARCHIVE_OK)
             return (r);
-        r = archive_write_data_block(aw, buff, size, (int)offset);
+        r = archive_write_data_block(aw, buff, size, (size_t)offset);
         if (r < ARCHIVE_OK) {
             return (r);
     }

--- a/src/conda_package_handling/tarball.py
+++ b/src/conda_package_handling/tarball.py
@@ -137,7 +137,7 @@ class CondaTarBZ2(AbstractBaseFormat):
             try:
                 _tar_xf(fn, dest_dir)
             except InvalidArchiveError:
-                LOG.warn(
+                LOG.warning(
                     "Failed extraction with libarchive... falling back to python implementation"
                 )
                 _tar_xf_no_libarchive(fn, dest_dir)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -188,6 +188,10 @@ def test_secure_refusal_to_extract_abs_paths(testing_workdir):
     with tarfile.open('pinkie.tar.bz2', 'w:bz2') as tf:
         open('thebrain', 'w').close()
         tf.add(os.path.join(testing_workdir, 'thebrain'), '/naughty/abs_path')
+        try:
+            tf.getmember('/naughty/abs_path')
+        except KeyError:
+            pytest.skip("Tar implementation does not generate unsafe paths in archive.")
 
     with pytest.raises(api.InvalidArchiveError):
         api.extract('pinkie.tar.bz2')


### PR DESCRIPTION
@mingwandroid could you take a look at this... fallback implemented as requested. `size_t` fix resolves #71. 

I don't know the details of seeking in archives well enough to work it what is minimally required to trigger this bug and so reproduce it in a sensible way for regression testing. If I used `fallocate` for a few files of a GB to create a sufficiently large archive it still did not trigger the observed error. Nevertheless, the archive shared in #71 was sufficient to reproduce and confirm the fix for the bug.

I think I fixed an issue with Travis CI... I will debug if my hope is misplaced.
