### PR TITLE
compute package hashes in threads

### DIFF
--- a/src/conda_package_handling/conda_fmt.py
+++ b/src/conda_package_handling/conda_fmt.py
@@ -91,12 +91,8 @@ class CondaFormat_v2(AbstractBaseFormat):
         return conda_pkg_fn
 
     @staticmethod
-    def get_pkg_details(in_file):
+    def get_pkg_details(in_file): # XXX
         stat_result = os.stat(in_file)
         size = stat_result.st_size
-        # open the file twice because we need to start from the beginning each time
-        with open(in_file, 'rb') as f:
-            md5 = utils.md5_checksum(f)
-        with open(in_file, 'rb') as f:
-            sha256 = utils.sha256_checksum(f)
+        md5, sha256 = utils.checksums(in_file, ("md5", "sha256"))
         return {"size": size, "md5": md5, "sha256": sha256}

--- a/src/conda_package_handling/conda_fmt.py
+++ b/src/conda_package_handling/conda_fmt.py
@@ -91,7 +91,7 @@ class CondaFormat_v2(AbstractBaseFormat):
         return conda_pkg_fn
 
     @staticmethod
-    def get_pkg_details(in_file): # XXX
+    def get_pkg_details(in_file):
         stat_result = os.stat(in_file)
         size = stat_result.st_size
         md5, sha256 = utils.checksums(in_file, ("md5", "sha256"))

--- a/src/conda_package_handling/tarball.py
+++ b/src/conda_package_handling/tarball.py
@@ -166,9 +166,5 @@ class CondaTarBZ2(AbstractBaseFormat):
     def get_pkg_details(in_file):
         stat_result = os.stat(in_file)
         size = stat_result.st_size
-        # open the file twice because we need to start from the beginning each time
-        with open(in_file, 'rb') as f:
-            md5 = utils.md5_checksum(f)
-        with open(in_file, 'rb') as f:
-            sha256 = utils.sha256_checksum(f)
+        md5, sha256 = utils.checksums(in_file, ('md5', 'sha256'))
         return {"size": size, "md5": md5, "sha256": sha256}


### PR DESCRIPTION
Compute package hashes in threads. The time taken is slightly longer than the time taken to do the slowest (sha256) hash. In my testing of a partial mirror this was the difference between 6.78s in `utils._checksum` to 4.60s in `utils.checksums`.

It's also possible to `open()` the file only once and submit each block to each thread, but that is harder to get right and it doesn't save much time to avoid the extra `open()`.

The buffer size doesn't seem to affect the timing much.