### PR TITLE
Fix setting base directory for creation of TemporaryDirectory

### DIFF
--- a/news/fix-44
+++ b/news/fix-44
@@ -1,0 +1,24 @@
+Enhancements:
+-------------
+
+* <news item>
+
+Bug fixes:
+----------
+
+* Fix running from a read-only working directory (#44)
+
+Deprecations:
+-------------
+
+* <news item>
+
+Docs:
+-----
+
+* <news item>
+
+Other:
+------
+
+* <news item>

--- a/src/conda_package_handling/api.py
+++ b/src/conda_package_handling/api.py
@@ -104,7 +104,7 @@ def _convert(fn, out_ext, out_folder, **kw):
     out_fn = _os.path.join(out_folder, basename + out_ext)
     errors = ""
     if not _os.path.lexists(out_fn) or ('force' in kw and kw['force']):
-        with _TemporaryDirectory(prefix=out_folder) as tmp:
+        with _TemporaryDirectory(dir=out_folder) as tmp:
             try:
                 extract(fn, dest_dir=tmp)
                 file_list = _collect_paths(tmp)

--- a/src/conda_package_handling/conda_fmt.py
+++ b/src/conda_package_handling/conda_fmt.py
@@ -30,7 +30,7 @@ def _lookup_component_filename(zf, file_id, component_name):
 def _extract_component(fn, file_id, component_name, dest_dir=os.getcwd()):
     try:
         with ZipFile(fn, compression=ZIP_STORED) as zf:
-            with utils.TemporaryDirectory(prefix=dest_dir) as tmpdir:
+            with utils.TemporaryDirectory(dir=dest_dir) as tmpdir:
                 with utils.tmp_chdir(tmpdir):
                     component_filename = _lookup_component_filename(zf, file_id, component_name)
                     if not component_filename:
@@ -73,7 +73,7 @@ class CondaFormat_v2(AbstractBaseFormat):
         info_files = set(file_list) - set(pkg_files)
         ext, comp_filter, filter_opts = kw.get('compression_tuple') or DEFAULT_COMPRESSION_TUPLE
 
-        with utils.TemporaryDirectory(prefix=out_folder) as tmpdir:
+        with utils.TemporaryDirectory(dir=out_folder) as tmpdir:
             info_tarball = create_compressed_tarball(prefix, info_files, tmpdir, 'info-' + out_fn,
                                                     ext, comp_filter, filter_opts)
             pkg_tarball = create_compressed_tarball(prefix, pkg_files, tmpdir, 'pkg-' + out_fn,


### PR DESCRIPTION
<!---
Thanks for opening a PR on conda-package-handling!
 Please include a news entry with your PR to help keep our changelog up to date!
There are instructions available at: https://regro.github.io/rever-docs/news.html
 If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
 Thanks again!
-->

Before:

```python
In [1]: import conda_package_handling.api
   ...: !rm /tmp/ripgrep-13.0.0-habb4d0f_1.conda
   ...: conda_package_handling.api.transmute(
   ...:     "/home/cburr/miniconda3/pkgs/ripgrep-13.0.0-habb4d0f_1.tar.bz2",
   ...:     ".conda",
   ...:     out_folder="/tmp",
   ...: )

# Truncated

File ~/miniconda3/envs/diracos2-env-2/lib/python3.10/site-packages/conda_package_handling/api.py:107, in _convert(fn, out_ext, out_folder, **kw)
    105 errors = ""
    106 if not _os.path.lexists(out_fn) or ('force' in kw and kw['force']):
--> 107     with _TemporaryDirectory(prefix=out_folder) as tmp:
    108         try:
    109             extract(fn, dest_dir=tmp)

File ~/miniconda3/envs/diracos2-env-2/lib/python3.10/site-packages/conda_package_handling/utils.py:309, in TemporaryDirectory.__init__(self, suffix, prefix, dir)
    308 def __init__(self, suffix="", prefix='.cph_tmp', dir=os.getcwd()):
--> 309     self.name = mkdtemp(suffix, prefix, dir)

File ~/miniconda3/envs/diracos2-env-2/lib/python3.10/tempfile.py:368, in mkdtemp(suffix, prefix, dir)
    366 _sys.audit("tempfile.mkdtemp", file)
    367 try:
--> 368     _os.mkdir(file, 0o700)
    369 except FileExistsError:
    370     continue    # try again

PermissionError: [Errno 13] Permission denied: '/tmp1j04ae_y'
```

After:

```python
In [1]: import conda_package_handling.api
   ...: !rm /tmp/ripgrep-13.0.0-habb4d0f_1.conda
   ...: conda_package_handling.api.transmute(
   ...:     "/home/cburr/miniconda3/pkgs/ripgrep-13.0.0-habb4d0f_1.tar.bz2",
   ...:     ".conda",
   ...:     out_folder="/tmp",
   ...: )
Out[1]: {}
```

Fix #44