### PR TITLE
Sort info first

### DIFF
--- a/news/sort-info-first.rst
+++ b/news/sort-info-first.rst
@@ -1,0 +1,5 @@
+Bug fixes:
+----------
+
+* Include tested fix for "``info/`` sorts first in ``.tar.bz2``" feature, useful
+  for streaming ``.tar.bz2``

--- a/src/conda_package_handling/tarball.py
+++ b/src/conda_package_handling/tarball.py
@@ -25,7 +25,7 @@ def _sort_file_order(prefix, files):
         # we don't care about empty files so send them back via 100000
         fsize = os.lstat(os.path.join(prefix, f)).st_size or 100000
         # info/* records will be False == 0, others will be 1.
-        info_order = int(os.path.dirname(f) != 'info')
+        info_order = int(not f.startswith('info' + os.path.sep))
         if info_order:
             _, ext = os.path.splitext(f)
             # Strip any .dylib.* and .so.* and rename .dylib to .so
@@ -59,6 +59,11 @@ def _sort_file_order(prefix, files):
         s2 = set(files_list)
         if len(s1) > len(s2):
             files_list.extend(s1 - s2)
+        # move info/ to front
+        files_list = [f for _, f in
+            sorted(enumerate(files_list),
+            key=lambda fi: (not fi[1].startswith('info' + os.path.sep), fi[0]))
+        ]
     else:
         files_list = list(f for f in sorted(files, key=order))
     return files_list

--- a/src/conda_package_handling/tarball.py
+++ b/src/conda_package_handling/tarball.py
@@ -59,7 +59,7 @@ def _sort_file_order(prefix, files):
         s2 = set(files_list)
         if len(s1) > len(s2):
             files_list.extend(s1 - s2)
-        # move info/ to front
+        # move info/ to front, otherwise preserving current order fi[0]
         files_list = [f for _, f in
             sorted(enumerate(files_list),
             key=lambda fi: (not fi[1].startswith('info' + os.path.sep), fi[0]))

--- a/src/conda_package_handling/tarball.py
+++ b/src/conda_package_handling/tarball.py
@@ -21,11 +21,12 @@ LOG = logging.getLogger(__file__)
 
 def _sort_file_order(prefix, files):
     """Sort by filesize or by binsort, to optimize compression"""
+    info_slash = "info" +  os.path.sep
     def order(f):
         # we don't care about empty files so send them back via 100000
         fsize = os.lstat(os.path.join(prefix, f)).st_size or 100000
         # info/* records will be False == 0, others will be 1.
-        info_order = int(not f.startswith('info' + os.path.sep))
+        info_order = int(not f.startswith(info_slash))
         if info_order:
             _, ext = os.path.splitext(f)
             # Strip any .dylib.* and .so.* and rename .dylib to .so
@@ -60,12 +61,11 @@ def _sort_file_order(prefix, files):
         if len(s1) > len(s2):
             files_list.extend(s1 - s2)
         # move info/ to front, otherwise preserving current order fi[0]
-        files_list = [f for _, f in
-            sorted(enumerate(files_list),
-            key=lambda fi: (not fi[1].startswith('info' + os.path.sep), fi[0]))
-        ]
+        # (Python's sort algorithm is guaranteed to be stable, maintains 
+        # existing order of items with the same sort key)
+        files_list = list(sorted(files, key=lambda f: not f.startswith(info_slash)))
     else:
-        files_list = list(f for f in sorted(files, key=order))
+        files_list = list(sorted(files, key=order))
     return files_list
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -118,6 +118,27 @@ def test_api_transmute_tarball_to_conda_v2(testing_workdir):
     assert os.path.isfile(condafile)
     check_conda_v2_metadata(condafile)
 
+
+def test_api_transmute_tarball_info_sorts_first(testing_workdir):
+    for test_package in (test_package_name, test_package_name_2):
+        test_file = os.path.join(data_dir, test_package + '.tar.bz2')
+        # skip 'don't transmute to same extension' logic
+        fn, out_fn, errors = api._convert(test_file, '.tar.bz2', testing_workdir)
+        assert fn == test_file
+        assert not errors
+        # info must be first
+        with tarfile.open(out_fn, 'r:bz2') as repacked:
+            info_seen = False
+            not_info_seen = False
+            for member in repacked:
+                if member.name.startswith('info'):
+                    assert not_info_seen == False, 'package info/ must sort first'
+                    info_seen = True
+                else:
+                    not_info_seen = True
+            assert info_seen, 'package had no info/ files'
+
+
 @pytest.mark.skipif(sys.platform=="win32", reason="windows and symlinks are not great")
 def test_api_transmute_to_conda_v2_contents(testing_workdir):
     def _walk(path):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -121,22 +121,24 @@ def test_api_transmute_tarball_to_conda_v2(testing_workdir):
 
 def test_api_transmute_tarball_info_sorts_first(testing_workdir):
     for test_package in (test_package_name, test_package_name_2):
-        test_file = os.path.join(data_dir, test_package + '.tar.bz2')
+        test_file = os.path.join(data_dir, test_package + ".tar.bz2")
         # skip 'don't transmute to same extension' logic
-        fn, out_fn, errors = api._convert(test_file, '.tar.bz2', testing_workdir)
+        fn, out_fn, errors = api._convert(test_file, ".tar.bz2", testing_workdir)
         assert fn == test_file
         assert not errors
         # info must be first
-        with tarfile.open(out_fn, 'r:bz2') as repacked:
+        with tarfile.open(out_fn, "r:bz2") as repacked:
             info_seen = False
             not_info_seen = False
             for member in repacked:
-                if member.name.startswith('info'):
-                    assert not_info_seen == False, f'package info/ must sort first, unlike {[m.name for m in repacked.getmembers()]}'
+                if member.name.startswith("info"):
+                    assert (
+                        not_info_seen == False
+                    ), f"{test_package} package info/ must sort first, but {[m.name for m in repacked.getmembers()]}"
                     info_seen = True
                 else:
                     not_info_seen = True
-            assert info_seen, 'package had no info/ files'
+            assert info_seen, "package had no info/ files"
 
 
 @pytest.mark.skipif(sys.platform=="win32", reason="windows and symlinks are not great")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -120,7 +120,11 @@ def test_api_transmute_tarball_to_conda_v2(testing_workdir):
 
 
 def test_api_transmute_tarball_info_sorts_first(testing_workdir):
-    for test_package in (test_package_name, test_package_name_2):
+    test_packages = [test_package_name]
+    test_packages_with_symlinks = [test_package_name_2]
+    if sys.platform != 'win32':
+        test_packages += test_packages_with_symlinks
+    for test_package in test_packages:
         test_file = os.path.join(data_dir, test_package + ".tar.bz2")
         # skip 'don't transmute to same extension' logic
         fn, out_fn, errors = api._convert(test_file, ".tar.bz2", testing_workdir)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -132,7 +132,7 @@ def test_api_transmute_tarball_info_sorts_first(testing_workdir):
             not_info_seen = False
             for member in repacked:
                 if member.name.startswith('info'):
-                    assert not_info_seen == False, 'package info/ must sort first'
+                    assert not_info_seen == False, f'package info/ must sort first, unlike {[m.name for m in repacked.getmembers()]}'
                     info_seen = True
                 else:
                     not_info_seen = True


### PR DESCRIPTION
This old feature didn't work as intended, and `info/` appeared to be distributed randomly through the `.tar.bz2'. Fixes #101 

Will info start with `info\` (different os.path.sep) on Windows, in this function?