### PR TITLE
attempt wrapper for decompress from custom reader

### DIFF
--- a/src/conda_package_handling/archive_utils_cy.pyx
+++ b/src/conda_package_handling/archive_utils_cy.pyx
@@ -10,6 +10,37 @@ cdef extern from "archive_utils_c.c":
     int add_file(void *a, void *entry, const char *filename, const char **err_str)
     int extract_file_c(const char *filename, const char **err_str)
 
+    struct archive:
+        pass
+
+    int	*archive_open_callback(archive *, void *_client_data);
+    size_t *archive_read_callback(archive *, void *_client_data, const void **_buffer);
+    int *archive_close_callback(archive *, void *_client_data);
+
+    archive* archive_read_new();
+    int archive_read_open(
+        archive *,
+        void *_client_data,
+        archive_open_callback *,
+        archive_read_callback *,
+        archive_close_callback *
+        );
+    int archive_read_support_filter_all(archive *);
+
+#define	ARCHIVE_EOF	  1	/* Found end of archive. */
+#define	ARCHIVE_OK	  0	/* Operation was successful. */
+#define	ARCHIVE_RETRY	(-10)	/* Retry might succeed. */
+#define	ARCHIVE_WARN	(-20)	/* Partial success. */
+# /* For example, if write_header "fails", then you can't push data. */
+#define	ARCHIVE_FAILED	(-25)	/* Current operation cannot complete. */
+# /* But if write_header is "fatal," then this archive is dead and useless. */
+#define	ARCHIVE_FATAL	(-30)	/* No more operations are possible. */
+
+ARCHIVE_OK = 0
+
+
+from cython.operator import dereference
+
 
 def extract_file(tarball):
     """Extract a tarball into the current directory."""
@@ -39,3 +70,47 @@ def create_archive(fullpath, files, compression_filter, compression_opts):
     close_entry(entry)
     close_archive(a)
     return 0, b'', b''
+
+
+cdef ssize_t myread(archive *a, void *client_data, const void **buff):
+    func = <object>client_data
+
+    dereference(buff) = mydata.buff;
+    buf = func(10240)
+    # return (read(mydata.fd, mydata.buff, 10240));
+    # copy Python buffer to C buffer, or use buffer protocol
+
+    return len(buf)
+
+
+cdef int myopen(archive *a, void *client_data):
+    func = <object>client_data
+
+    # Python file-like should already be open
+    # Check for read method?
+    # mydata->fd = open(mydata->name, O_RDONLY);
+    # return (mydata->fd >= 0 ? ARCHIVE_OK : ARCHIVE_FATAL);
+
+    return ARCHIVE_OK
+
+
+cdef int myclose( archive *a, void *client_data):
+    func = <object>client_data
+
+    # drop a refcount?
+
+    # if (mydata->fd > 0):
+    #     close(mydata->fd)
+
+    return ARCHIVE_OK;
+
+
+def read_zstd(reader):
+    """Decompress .zstd given a reader with a .read() method"""
+    cdef archive *a;
+
+    a = archive_read_new();
+    archive_read_support_filter_all(a);
+    # archive_read_support_format_all(a);
+    archive_read_open(a, <void*>reader, myopen, myread, myclose);
+

--- a/src/conda_package_handling/archive_utils_cy.pyx
+++ b/src/conda_package_handling/archive_utils_cy.pyx
@@ -17,7 +17,7 @@ cdef extern from "archive_utils_c.c":
         pass
 
     ctypedef int (*archive_open_callback)(archive *, void *_client_data);
-    ctypedef size_t (*archive_read_callback)(archive *, void *_client_data, const void **_buffer);
+    ctypedef ssize_t (*archive_read_callback)(archive *, void *_client_data, const void **_buffer);
     ctypedef int (*archive_close_callback)(archive *, void *_client_data);
 
     archive* archive_read_new();
@@ -167,7 +167,6 @@ def read_zstd(reader):
         <archive_read_callback*>&myread,
         <archive_close_callback*>&myclose
         ))
-
     archive_check(a);
 
     archive_read_next_header(a, &ae);

--- a/unzst.py
+++ b/unzst.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+# Unpack zstd usin new thingy
+
+from conda_package_handling import archive_utils_cy
+
+a = archive_utils_cy.read_zstd(open("setup.py.zst", "rb").read)
+
+print(f"read_zstd says {a}")


### PR DESCRIPTION
I was able to get zstd to extract from a Python read() function, to a string. Needs to provide a reader object back to Python code, handle errors, ensure refcount bugs are not there.

We already use `libarchive` in conda. If we can wrap libarchive to provide a read() method, given a Python reader, then we have a zstd compressor that doesn't have to read or write to disk. Then we can extract the `.tar.zst` from `.conda` directly, without first writing the embedded file to a temporary file.

A library like https://anaconda.org/main/zstandard is certainly better, unless you need to avoid adding dependencies to conda.

Fixes #103 