### PR TITLE
fix, test extracting .conda given as relative path

### DIFF
--- a/src/conda_package_handling/api.py
+++ b/src/conda_package_handling/api.py
@@ -2,11 +2,8 @@ import os as _os
 from glob import glob as _glob
 import functools as _functools
 import tempfile as _tempfile
-from typing import Dict
 
 import tqdm as _tqdm
-
-from conda_package_handling.interface import AbstractBaseFormat
 
 # expose these two exceptions as part of the API.  Everything else should feed into these.
 from .exceptions import ConversionError, InvalidArchiveError  # NOQA
@@ -15,7 +12,7 @@ from .conda_fmt import CondaFormat_v2 as _CondaFormat_v2
 from .utils import (TemporaryDirectory as _TemporaryDirectory, rm_rf as _rm_rf,
                     get_executor as _get_executor)
 
-SUPPORTED_EXTENSIONS: Dict[str, AbstractBaseFormat] = {'.tar.bz2': _CondaTarBZ2,
+SUPPORTED_EXTENSIONS = {'.tar.bz2': _CondaTarBZ2,
                         '.conda': _CondaFormat_v2}
 
 

--- a/src/conda_package_handling/interface.py
+++ b/src/conda_package_handling/interface.py
@@ -6,6 +6,11 @@ class AbstractBaseFormat(metaclass=abc.ABCMeta):
 
     @staticmethod
     @abc.abstractmethod
+    def supported(fn):
+        return False
+
+    @staticmethod
+    @abc.abstractmethod
     def extract(fn, dest_dir, **kw):
         raise NotImplementedError
 

--- a/src/conda_package_handling/tarball.py
+++ b/src/conda_package_handling/tarball.py
@@ -61,7 +61,7 @@ def _sort_file_order(prefix, files):
         if len(s1) > len(s2):
             files_list.extend(s1 - s2)
         # move info/ to front, otherwise preserving current order fi[0]
-        # (Python's sort algorithm is guaranteed to be stable, maintains 
+        # (Python's sort algorithm is guaranteed to be stable, maintains
         # existing order of items with the same sort key)
         files_list = list(sorted(files, key=lambda f: not f.startswith(info_slash)))
     else:
@@ -138,6 +138,10 @@ def _tar_xf_no_libarchive(tarball_full_path, destination_directory=None):
 
 
 class CondaTarBZ2(AbstractBaseFormat):
+
+    @staticmethod
+    def supported(fn):
+        return fn.endswith('.tar.bz2')
 
     @staticmethod
     def extract(fn, dest_dir, **kw):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -74,6 +74,22 @@ def test_api_extract_conda_v2_implicit_path(testing_workdir):
     assert os.path.isfile(os.path.join(testing_workdir, test_package_name, 'info', 'index.json'))
 
 
+def test_api_extract_conda_v2_no_destdir_relative_path(testing_workdir):
+    cwd = os.getcwd()
+    os.chdir(testing_workdir)
+    try:
+        condafile = os.path.join(data_dir, test_package_name + '.conda')
+        local_condafile = os.path.join(testing_workdir, os.path.basename(condafile))
+        shutil.copy2(condafile, local_condafile)
+
+        condafile = os.path.basename(local_condafile)
+        assert os.path.exists(condafile)
+        # cli passes dest=None, prefix=None
+        api.extract(condafile, None, prefix=None)
+    finally:
+        os.chdir(cwd)
+
+
 def test_api_extract_conda_v2_explicit_path(testing_workdir):
     tarfile = os.path.join(data_dir, test_package_name + '.conda')
     local_tarfile = os.path.join(testing_workdir, os.path.basename(tarfile))


### PR DESCRIPTION
Test for #115

Can extract `/full/path/to/*.conda` but not `*.conda`