### PR TITLE
Rename master to main

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,17 +1,12 @@
 name: CI
 
 on:
-  # GitHub has started calling new repo's first branch "main" https://github.com/github/renaming
-  # Existing codes likely still have "master" as the primary branch
-  # Both are tracked here to keep legacy and new codes working
   push:
     branches:
-      - "master"
-      - "main"
+      - main
   pull_request:
     branches:
-      - "master"
-      - "main"
+      - main
 
 jobs:
   test:


### PR DESCRIPTION
The minor modifications needed for renaming the default branch from master to main.

Xref: https://github.com/conda/conda/issues/11517