### PR TITLE
Rever 1.9.0

### DIFF
--- a/.authors.yml
+++ b/.authors.yml
@@ -54,7 +54,7 @@
   first_commit: 2021-04-12 11:49:45
 - name: conda-bot
   email: ad-team+condabot@anaconda.com
-  num_commits: 3
+  num_commits: 10
   first_commit: 2022-01-25 21:32:39
   alternate_emails:
   - 18747875+conda-bot@users.noreply.github.com
@@ -70,7 +70,7 @@
   first_commit: 2022-02-17 10:23:53
 - name: Daniel Holth
   email: dholth@anaconda.com
-  num_commits: 2
+  num_commits: 5
   first_commit: 2021-08-20 21:11:50
   github: dholth
 - name: vz-x
@@ -83,9 +83,22 @@
   first_commit: 2022-02-09 01:00:38
 - name: Jannis Leidel
   email: jannis@leidel.info
-  num_commits: 6
+  num_commits: 9
   first_commit: 2021-09-17 21:51:27
 - name: Tobias "Tobi" Koch
   email: tkoch@anaconda.com
   num_commits: 1
   first_commit: 2022-03-31 19:54:23
+- name: Marius van Niekerk
+  email: marius.v.niekerk@gmail.com
+  num_commits: 1
+  first_commit: 2022-07-19 15:55:18
+- name: Ken Odegard
+  email: kodegard@anaconda.com
+  num_commits: 3
+  first_commit: 2022-06-15 15:11:13
+- name: conda bot
+  email: 18747875+conda-bot@users.noreply.github.com
+
+  num_commits: 3
+  first_commit: 2022-03-30 14:32:25

--- a/.authors.yml
+++ b/.authors.yml
@@ -52,12 +52,15 @@
   email: 2790401+dbast@users.noreply.github.com
   num_commits: 2
   first_commit: 2021-04-12 11:49:45
+  github: dbast
 - name: conda-bot
-  email: ad-team+condabot@anaconda.com
+  email:  ad-team+condabot@anaconda.com
   num_commits: 10
   first_commit: 2022-01-25 21:32:39
-  alternate_emails:
-  - 18747875+conda-bot@users.noreply.github.com
+  github: conda-bot
+- name: conda-bot
+  email: "18747875+conda-bot@users.noreply.github.com"
+  github: conda-bot
 - name: Cheng H. Lee
   email: clee@anaconda.com
   alternate_emails:
@@ -85,6 +88,7 @@
   email: jannis@leidel.info
   num_commits: 9
   first_commit: 2021-09-17 21:51:27
+  github: jezdez
 - name: Tobias "Tobi" Koch
   email: tkoch@anaconda.com
   num_commits: 1
@@ -93,12 +97,9 @@
   email: marius.v.niekerk@gmail.com
   num_commits: 1
   first_commit: 2022-07-19 15:55:18
+  github: mariusvniekerk
 - name: Ken Odegard
   email: kodegard@anaconda.com
   num_commits: 3
   first_commit: 2022-06-15 15:11:13
-- name: conda bot
-  email: 18747875+conda-bot@users.noreply.github.com
-
-  num_commits: 3
-  first_commit: 2022-03-30 14:32:25
+  github: kenodegard

--- a/.mailmap
+++ b/.mailmap
@@ -14,17 +14,20 @@ Michael Sarahan <msarahan@gmail.com> Mike Sarahan <msarahan@anaconda.com>
 Ray Donnelly <mingw.android@gmail.com>
 leej3 <johnleenimh@gmail.com>
 Jonathan J. Helmus <jjhelmus@gmail.com>
+conda-bot <ad-team+condabot@anaconda.com> conda-bot <18747875+conda-bot@users.noreply.github.com>
 Jannis Leidel <jannis@leidel.info>
+Daniel Holth <dholth@anaconda.com>
 Nehal J Wani <nehaljw.kkd1@gmail.com>
 Alan Du <alanhdu@gmail.com>
 Cheng H. Lee <clee@anaconda.com> Cheng H. Lee <chenghlee@users.noreply.github.com>
-conda-bot <ad-team+condabot@anaconda.com> conda-bot <18747875+conda-bot@users.noreply.github.com>
+Ken Odegard <kodegard@anaconda.com>
+conda bot <18747875+conda-bot@users.noreply.github.com>
 Matthew R. Becker <beckermr@users.noreply.github.com>
 Daniel Bast <2790401+dbast@users.noreply.github.com>
-Daniel Holth <dholth@anaconda.com>
 Christopher Barber <christopher.barber@analog.com>
 ossdev07 <ossdev@puresoftware.com>
 Eli Uriegas <seemethere101@gmail.com>
 Chris Burr <chrisburr@users.noreply.github.com>
 vz-x <77290357+vz-x@users.noreply.github.com>
 Tobias "Tobi" Koch <tkoch@anaconda.com>
+Marius van Niekerk <marius.v.niekerk@gmail.com>

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -5,17 +5,20 @@ Authors are sorted by number of commits.
 * Ray Donnelly
 * leej3
 * Jonathan J. Helmus
+* conda-bot
 * Jannis Leidel
+* Daniel Holth
 * Nehal J Wani
 * Alan Du
 * Cheng H. Lee
-* conda-bot
+* Ken Odegard
+* conda bot
 * Matthew R. Becker
 * Daniel Bast
-* Daniel Holth
 * Christopher Barber
 * ossdev07
 * Eli Uriegas
 * Chris Burr
 * vz-x
 * Tobias "Tobi" Koch
+* Marius van Niekerk

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,20 @@
 .. current developments
 
+2022-09-06 1.9.0:
+==================
+
+Contributors:
+-------------
+
+* @conda-bot
+* @jezdez
+* @dholth
+* @kenodegard
+* @conda-bot
+* @mariusvniekerk
+
+
+
 2022-04-01 1.8.1:
 ==================
 

--- a/news/sort-info-first.rst
+++ b/news/sort-info-first.rst
@@ -1,5 +1,0 @@
-Bug fixes:
-----------
-
-* Include tested fix for "``info/`` sorts first in ``.tar.bz2``" feature, useful
-  for streaming ``.tar.bz2``


### PR DESCRIPTION
### Description

Changes to make rever work. `alternate_email` is not consulted when looking up github handles from commits unfortunately, so we have to list `conda-bot` 2x.

The news for this release has not been automatically included.