### PR TITLE
Add canary release action job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,10 +15,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
 
     - name: Additional info about the build
       shell: bash
@@ -47,6 +47,45 @@ jobs:
       shell: bash -l {0}
       run: |
         conda build -c conda conda.recipe
+
+  canary:
+    name: Canary Build
+    needs: [test]
+    # only build canary build if
+    # - prior steps succeeded,
+    # - this is the main repo, and
+    # - we are on the main (or feature) branch
+    if: >-
+      success()
+      && !github.event.repository.fork
+      && (
+        github.ref_name == 'main'
+        || startsWith(github.ref_name, 'feature/')
+      )
+    strategy:
+      matrix:
+        include:
+          # build only on linux due to noarch
+          - runner: ubuntu-latest
+            subdir: linux-64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      # Clean checkout of specific git ref needed for package metadata version
+      # which needs env vars GIT_DESCRIBE_TAG and GIT_BUILD_STR:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+          clean: true
+          fetch-depth: 0
+
+      - name: Create and upload canary build
+        uses: conda/actions/canary-release@v22.10.0
+        with:
+          package-name: ${{ github.event.repository.name }}
+          subdir: ${{ matrix.subdir }}
+          anaconda-org-channel: conda-canary
+          anaconda-org-label: ${{ github.ref_name == 'main' && 'dev' || github.ref_name }}
+          anaconda-org-token: ${{ secrets.ANACONDA_ORG_CONDA_CANARY_TOKEN }}
 
 # TODO: Re-enable codecov when we figure out how to grab coverage from the conda build
 #       environment

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,18 +1,13 @@
-{% set name = "conda-package-handling" %}
-{% set version_match = load_file_regex(
-  load_file="src/conda_package_handling/__init__.py",
-  regex_pattern='^__version__ = "(.+)"') %}
-{% set version = version_match[1] %}
-
 package:
-  name: {{ name }}
-  version: {{ version }}
+  name: conda-package-handling
+  version: {{ GIT_DESCRIBE_TAG }}+{{ GIT_BUILD_STR }}
 
 source:
   - path: ..
 
 build:
   number: 0
+  noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - cph = conda_package_handling.cli:main
@@ -20,11 +15,11 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3.7
     - pip
     - wheel
   run:
-    - python
+    - python >=3.7
     - conda-package-streaming >=0.7.0
 
 test:


### PR DESCRIPTION
As this package is installed into every conda installation, changes have a great impact. A canary release allows to easy test the package by a wider audience before a release is out.

This also converts the recipe:
* to be noarch: the code is noarch and it is noarch on conda-forge, noarch also allows testinng the canary build on exotic platforms like s390x where we annot easily build for via the canary action.
* to derive its package version from git history (like git describe --tags) to generate a unique increasing version per each merged PR.

The code is 1:1 from the conda repo.

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [ ] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
