### PR TITLE
calculate size in CondaFormat_v2.create()

### DIFF
--- a/news/171-zstd-size
+++ b/news/171-zstd-size
@@ -1,0 +1,22 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Include decompressed size when creating `.conda` archives with
+  `CondaFormat_v2.create()`, to reduce memory usage on decompression. (#171)
+  Transmuted archives (converted from `.tar.bz2`) do not contain the
+  decompressed size.
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/src/conda_package_handling/conda_fmt.py
+++ b/src/conda_package_handling/conda_fmt.py
@@ -121,8 +121,7 @@ class CondaFormat_v2(AbstractBaseFormat):
                 with tarfile.TarFile(fileobj=NullWriter(), mode="w") as sizer:  # type: ignore
                     for file in files:
                         sizer.add(file, filter=utils.anonymize_tarinfo)
-                    sizer.close()
-                    size = sizer.fileobj.size  # type: ignore
+                size = sizer.fileobj.size  # type: ignore
 
                 with conda_file.open(component, "w") as component_file:
                     # only one stream_writer() per compressor() must be in use at a time


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This should reduce memory usage on extract. We create a throwaway tar to find the size, then repeat to compress. The decompressor will be able to see the total decompressed size when allocating buffers.

We could return to creating temporary files to get the size, but this is simpler. Unsure how the timing compares.

#171 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
