### PR TITLE
Log sha256 of created packages

### DIFF
--- a/news/209-log-sha256
+++ b/news/209-log-sha256
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Log sha256 of created packages. It allows to co-relate build/transmute logs with cryptographic safety, meaning any package in the wild can via its sha256 traced back to its build log with very high probability as sha256 collisions are very unlikely/hard to generate. (#209)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/src/conda_package_handling/conda_fmt.py
+++ b/src/conda_package_handling/conda_fmt.py
@@ -7,6 +7,7 @@ https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/packages.html
 from __future__ import annotations
 
 import json
+import logging
 import os
 import tarfile
 from typing import Callable
@@ -25,6 +26,9 @@ DEFAULT_COMPRESSION_TUPLE = (".tar.zst", "zstd", "zstd:compression-level=19")
 ZSTD_COMPRESS_LEVEL = 19
 # increase to reduce compression (slightly) and increase speed
 ZSTD_COMPRESS_THREADS = 1
+
+
+LOG = logging.getLogger(__name__)
 
 
 class CondaFormat_v2(AbstractBaseFormat):
@@ -133,6 +137,10 @@ class CondaFormat_v2(AbstractBaseFormat):
 
                     component_tar.close()
                     component_stream.close()
+
+        LOG.info(
+            "Created '%s' with sha256 '%s'", conda_pkg_fn, CondaFormat_v2.get_sha256(conda_pkg_fn)
+        )
 
         return conda_pkg_fn
 

--- a/src/conda_package_handling/interface.py
+++ b/src/conda_package_handling/interface.py
@@ -1,4 +1,5 @@
 import abc
+import hashlib
 import os
 
 
@@ -22,3 +23,15 @@ class AbstractBaseFormat(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def get_pkg_details(in_file):  # pragma: no cover
         raise NotImplementedError
+
+    @staticmethod
+    def get_sha256(file_path: str, chunk_size: int = 1_048_576) -> str:
+        hasher = hashlib.sha256()
+        with open(file_path, "rb") as f:
+            while True:
+                chunk = f.read(chunk_size)
+                if not chunk:
+                    break
+                hasher.update(chunk)
+
+        return hasher.hexdigest()

--- a/src/conda_package_handling/tarball.py
+++ b/src/conda_package_handling/tarball.py
@@ -6,7 +6,7 @@ import tarfile
 from . import streaming, utils
 from .interface import AbstractBaseFormat
 
-LOG = logging.getLogger(__file__)
+LOG = logging.getLogger(__name__)
 
 
 def _sort_file_order(prefix, files):
@@ -81,6 +81,9 @@ class CondaTarBZ2(AbstractBaseFormat):
             ".tar.bz2",
             "bzip2",
         )
+
+        LOG.info("Created '%s' with sha256 '%s'", out_file, CondaTarBZ2.get_sha256(out_file))
+
         return out_file
 
     @staticmethod


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This logs the sha256 of every created package, no matter if called from conda-build or done via transmute.

It allows to co-relate build/transmute logs with cryptographic safety, meaning any package in the wild can via its sha256 traced back to its build log with very high probability as sha256 collisions are very unlikely/hard to generate.  

Not yet 100% sure if that is the right place to do... it could be also done within conda-build right after the create call.. though doing it in cph also covers the transmute case.

@jaimergp maybe also interesting for you :) 

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
