### PR TITLE
Update python matrix (add 3.10, 3.11, 3.12 - drop 3.7)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, '3.10', 3.11, 3.12]
 
     steps:
     - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     rev: v3.15.0
     hooks:
       - id: pyupgrade
-        args: ["--py37-plus"]
+        args: ["--py38-plus"]
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0
     hooks:

--- a/news/python-update
+++ b/news/python-update
@@ -1,6 +1,6 @@
 ### Enhancements
 
-* Added formal support for Python 3.10, 3.11, and 3.12
+* Added formal support for Python 3.10, 3.11, and 3.12. (#231)
 
 ### Bug fixes
 

--- a/news/python-update
+++ b/news/python-update
@@ -8,7 +8,7 @@
 
 ### Deprecations
 
-* Removed formal support for Python 3.7
+* Removed formal support for Python 3.7. (#231)
 
 ### Docs
 

--- a/news/python-update
+++ b/news/python-update
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Added formal support for Python 3.10, 3.11, and 3.12
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Removed formal support for Python 3.7
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     entry_points={"console_scripts": ["cph=conda_package_handling.cli:main"]},
     keywords="conda-package-handling",
     classifiers=["Programming Language :: Python :: 3"],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=["conda-package-streaming >= 0.9.0"],
     extras_require={
         "docs": ["furo", "sphinx", "sphinx-argparse", "myst-parser", "mdit-py-plugins>=0.3.0"],

--- a/tests/memory_test.py
+++ b/tests/memory_test.py
@@ -1,6 +1,7 @@
 """
 Simple test for evaluating zstandard binding memory usage.
 """
+
 import io
 import sys
 


### PR DESCRIPTION
### Description

- Removes python 3.7
    - Because `conda` no longer supports 3.7
- Adds python 3.10, 3.11, and 3.12
    - All Supported by `conda` now

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
- [ ] Add / update necessary tests?
- [ ] Add / update outdated documentation?
    - I don't see any documentation that shows the python version range

### Extra Note

In `python 3.12` this now raises the following warning:

> `DeprecationWarning: Python 3.14 will, by default, filter extracted tar archives and reject files or modify their metadata. Use the filter argument to control this behavior.`

That relates to https://docs.python.org/3/library/tarfile.html#extraction-filters and specifically in 3.8->3.12 an non-specified filter will default to `fully_trusted` which may not be secure.  I went with *not* altering the behavior in this PR, but a followup issue should be filed/acted on to decide how we want to proceed.

This is a warning that is also present on `3.12` CI for `conda` itself.