### PR TITLE
Use force_zip64=True when directly creating .conda files

### DIFF
--- a/news/248-use-zip64
+++ b/news/248-use-zip64
@@ -1,0 +1,20 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Use force_zip64=True when directly creating .conda files. Allows >2GB
+  (compressed) size. (#248)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/src/conda_package_handling/conda_fmt.py
+++ b/src/conda_package_handling/conda_fmt.py
@@ -123,7 +123,7 @@ class CondaFormat_v2(AbstractBaseFormat):
                         sizer.add(file, filter=utils.anonymize_tarinfo)
                 size = sizer.fileobj.size  # type: ignore
 
-                with conda_file.open(component, "w") as component_file:
+                with conda_file.open(component, "w", force_zip64=True) as component_file:
                     # only one stream_writer() per compressor() must be in use at a time
                     component_stream = compress.stream_writer(
                         component_file, size=size, closefd=False


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Address same issue as https://github.com/conda/conda-package-streaming/issues/79 but when creating .conda directly (handled by conda-package-handling) , not converting from .tar.bz2 (handled by conda-package-streaming).

Fix #248 

Tested by running `dd if=/dev/urandom of=random bs=1M count=2048` and `cph c . /tmp/big.conda`, which will create a 2147533062-byte `pkg-big.tar.zst`, fail on the older code and succeed after this fix.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [x] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
