### PR TITLE
Expose the `components` kwarg in the CLI and API

### DIFF
--- a/news/253-components-list
+++ b/news/253-components-list
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Expose API and CLI for which components will be listed as part of `cph list`. (#253)
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/src/conda_package_handling/api.py
+++ b/src/conda_package_handling/api.py
@@ -9,6 +9,7 @@ from glob import glob as _glob
 from .exceptions import ConversionError, InvalidArchiveError  # NOQA
 from .interface import AbstractBaseFormat
 from .tarball import CondaTarBZ2 as _CondaTarBZ2
+from .utils import ensure_list
 from .utils import filter_info_files
 from .utils import get_executor as _get_executor
 from .utils import rm_rf as _rm_rf
@@ -227,8 +228,9 @@ def get_pkg_details(in_file):
     raise ValueError(f"Don't know what to do with file {in_file}")
 
 
-def list_contents(in_file, verbose=False):
+def list_contents(in_file, verbose=False, components=None):
+    components = ensure_list(components or ("info", "pkg"))
     for format in SUPPORTED_EXTENSIONS.values():
         if format.supported(in_file):
-            return format.list_contents(in_file, verbose=verbose)
+            return format.list_contents(in_file, verbose=verbose, components=components)
     raise ValueError(f"Don't know what to do with file {in_file}")

--- a/src/conda_package_handling/api.py
+++ b/src/conda_package_handling/api.py
@@ -9,8 +9,7 @@ from glob import glob as _glob
 from .exceptions import ConversionError, InvalidArchiveError  # NOQA
 from .interface import AbstractBaseFormat
 from .tarball import CondaTarBZ2 as _CondaTarBZ2
-from .utils import ensure_list
-from .utils import filter_info_files
+from .utils import ensure_list, filter_info_files
 from .utils import get_executor as _get_executor
 from .utils import rm_rf as _rm_rf
 

--- a/src/conda_package_handling/cli.py
+++ b/src/conda_package_handling/cli.py
@@ -116,6 +116,12 @@ def build_parser():
         action="store_true",
         help="Report more details, similar to 'ls -l'. Otherwise, only the filenames are printed.",
     )
+    list_parser.add_argument(
+        "--no-info",
+        action="store_false",
+        dest="info",
+        help="Do not list files from the 'info/' directory (.conda artifacts only).",
+    )
 
     return parser
 
@@ -148,7 +154,8 @@ def main(args=None):
             pprint(failed_files)
             sys.exit(1)
     elif args.subcommand in ("list", "l"):
-        api.list_contents(args.archive_path, verbose=args.verbose)
+        components = ("info", "pkg") if args.info else ("pkg",)
+        api.list_contents(args.archive_path, verbose=args.verbose, components=components)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/conda_package_handling/cli.py
+++ b/src/conda_package_handling/cli.py
@@ -117,10 +117,11 @@ def build_parser():
         help="Report more details, similar to 'ls -l'. Otherwise, only the filenames are printed.",
     )
     list_parser.add_argument(
-        "--no-info",
-        action="store_false",
-        dest="info",
-        help="Do not list files from the 'info/' directory (.conda artifacts only).",
+        "--components",
+        dest="components",
+        default="info,pkg",
+        help="Comma-separated list of components to read (.conda artifacts only; "
+        "ignored for .tar.bz2). Allowed values: info, pkg."
     )
 
     return parser
@@ -154,7 +155,7 @@ def main(args=None):
             pprint(failed_files)
             sys.exit(1)
     elif args.subcommand in ("list", "l"):
-        components = ("info", "pkg") if args.info else ("pkg",)
+        components = [component.strip() for component in (args.components or "info,pkg").split(",")]
         api.list_contents(args.archive_path, verbose=args.verbose, components=components)
 
 

--- a/src/conda_package_handling/cli.py
+++ b/src/conda_package_handling/cli.py
@@ -121,7 +121,7 @@ def build_parser():
         dest="components",
         default="info,pkg",
         help="Comma-separated list of components to read (.conda artifacts only; "
-        "ignored for .tar.bz2). Allowed values: info, pkg."
+        "ignored for .tar.bz2). Allowed values: info, pkg.",
     )
 
     return parser
@@ -155,7 +155,9 @@ def main(args=None):
             pprint(failed_files)
             sys.exit(1)
     elif args.subcommand in ("list", "l"):
-        components = [component.strip() for component in (args.components or "info,pkg").split(",")]
+        components = [
+            component.strip() for component in (args.components or "info,pkg").split(",")
+        ]
         api.list_contents(args.archive_path, verbose=args.verbose, components=components)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -82,3 +82,11 @@ def test_list(artifact, n_files, capsys):
 
     with pytest.raises(ValueError):
         cli.main(["list", "setup.py"])
+
+    cli.main(["list", os.path.join(data_dir, artifact), "--components=pkg"])
+    stdout, stderr = capsys.readouterr()
+    listed_files = sum(bool(line.strip()) for line in stdout.splitlines())
+    if artifact.endswith(".conda"):
+        assert listed_files < n_files  # info folder filtered out
+    else:
+        assert listed_files == n_files  # no info filtering in tar.bz2


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

Comes from https://github.com/conda-forge/conda-forge-ci-setup-feedstock/issues/328

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please still tick them so we know you've gone through the checklist. -->

- [x] Add a file to the `news` directory ([using the template](../blob/main/news/TEMPLATE)) for the next release's release notes?
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - other changes -->
- [x] Add / update necessary tests?
- [ ] Add / update outdated documentation?

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
