### PR TITLE
Fix pytest 9 compatibility: convert addopts to string

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,16 +55,7 @@ omit = [
 
 [tool.pytest.ini_options]
 norecursedirs = [".*", "*.egg*", "build", "dist", "conda.recipe"]
-addopts = [
-    "--junitxml=junit.xml",
-    "--ignore setup.py",
-    "--ignore run_test.py",
-    "--cov-report term-missing",
-    "--cov-branch",
-    "--tb native",
-    "--strict-markers",
-    "--durations=20",
-]
+addopts = "--junitxml=junit.xml --ignore setup.py --ignore run_test.py --cov-report term-missing --cov-branch --tb native --strict-markers --durations=20"
 markers = ["serial: execute test serially (to avoid race conditions)"]
 
 [tool.ruff]


### PR DESCRIPTION

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Under `[tool.pytest.ini_options]`, a TOML list for addopts treats each element as a single CLI argument. Multi-word entries like `--ignore setup.py` are passed as one argument instead of two, causing `file or directory not found: --ignore setup.py`. Convert addopts to an INI-style string where space-splitting handles this correctly.

### Checklist - did you ...

<!-- If any of the following items aren't relevant to your contribution,
     please either tick them or use ~strikethrough~ so we know you've gone
     through the checklist. -->

~- [ ] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-package-handling/blob/main/news/TEMPLATE)) for the next release's release notes?~
     <!-- All "significant" changes should get an entry:
            - user-facing changes or enhancements
            - bug fixes
            - deprecations
            - documentation updates
            - etc -->
~- [ ] Add / update necessary tests?~
~- [ ] Add / update outdated documentation?~


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/conda-package-handling/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/conda-package-handling/blob/main/CONTRIBUTING.md -->
