### PR TITLE
Drop Python 3.8/3.9 and add Python 3.14 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
 
 
     # More info on options: https://github.com/conda-incubator/setup-miniconda
-    - uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
+    - uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
       with:
         python-version: ${{ matrix.python-version }}
         environment-file: devtools/conda-envs/test_env.yaml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,7 @@ jobs:
     - uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
       with:
         python-version: ${{ matrix.python-version }}
+        conda-build-version: "*"
         environment-file: devtools/conda-envs/test_env.yaml
 
         channels: defaults
@@ -46,7 +47,7 @@ jobs:
       # conda setup requires this special shell
       shell: bash -l {0}
       run: |
-        conda-build -c conda -c conda-forge conda.recipe
+        conda build -c conda -c conda-forge conda.recipe
 
 # TODO: Re-enable codecov when we figure out how to grab coverage from the conda build
 #       environment

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.8, 3.9, '3.10', 3.11, 3.12]
+        python-version: ['3.10', 3.11, 3.12, 3.13, 3.14]
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
       # conda setup requires this special shell
       shell: bash -l {0}
       run: |
-        conda build -c conda -c conda-forge conda.recipe
+        conda-build -c conda -c conda-forge conda.recipe
 
 # TODO: Re-enable codecov when we figure out how to grab coverage from the conda build
 #       environment

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
         auto-activate-base: false
         show-channel-urls: true
 
-    - name: Install package
+    - name: Build and test package
 
       # conda setup requires this special shell
       shell: bash -l {0}

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -20,12 +20,12 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3.10
     - pip
     - wheel
     - flit
   run:
-    - python
+    - python >=3.10
     - zstandard >=0.15
     - conda-package-streaming >=0.9.0
     - requests

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
   run:
     - python >=3.10
     - zstandard >=0.15
-    - conda-package-streaming >=0.9.0
+    - conda-package-streaming >=0.12.0
     - requests
 
 test:

--- a/news/drop-py38-py39-add-py314
+++ b/news/drop-py38-py39-add-py314
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* <news item>
+* Require `conda-package-streaming >=0.12.0` for Python 3.14 compatibility.
 
 ### Deprecations
 

--- a/news/drop-py38-py39-add-py314
+++ b/news/drop-py38-py39-add-py314
@@ -1,0 +1,19 @@
+### Enhancements
+
+* Add Python 3.14 support.
+
+### Bug fixes
+
+* <news item>
+
+### Deprecations
+
+* Drop Python 3.8 and 3.9 support.
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/news/drop-py38-py39-add-py314
+++ b/news/drop-py38-py39-add-py314
@@ -1,14 +1,14 @@
 ### Enhancements
 
-* Add Python 3.14 support.
+* Add Python 3.14 support. (#328)
 
 ### Bug fixes
 
-* Require `conda-package-streaming >=0.12.0` for Python 3.14 compatibility.
+* Require `conda-package-streaming >=0.12.0` for Python 3.14 compatibility. (#328)
 
 ### Deprecations
 
-* Drop Python 3.8 and 3.9 support.
+* Drop Python 3.8 and 3.9 support. (#328)
 
 ### Docs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,16 @@ readme = "README.md"
 classifiers = [
   "License :: OSI Approved :: BSD License",
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dynamic = ["version"]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = ["conda-package-streaming >= 0.9.0", "requests", "zstandard >=0.15"]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 requires-python = ">=3.10"
-dependencies = ["conda-package-streaming >= 0.9.0", "requests", "zstandard >=0.15"]
+dependencies = ["conda-package-streaming >= 0.12.0", "requests", "zstandard >=0.15"]
 
 [project.scripts]
 cph = "conda_package_handling.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,6 @@ readme = "README.md"
 classifiers = [
   "License :: OSI Approved :: BSD License",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13",
-  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]

--- a/src/conda_package_handling/api.py
+++ b/src/conda_package_handling/api.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import functools as _functools
 import os as _os
 import warnings as _warnings
-from contextlib import suppress as _suppress
 from glob import glob as _glob
 
 # expose these two exceptions as part of the API.  Everything else should feed into these.
@@ -214,8 +213,10 @@ def transmute(in_file, out_ext, out_folder=None, processes=1, **kw):
         for fn, out_fn, errors in executor.map(convert_f, flist):
             if errors:
                 failed_files[fn] = errors
-                with _suppress(FileNotFoundError):
+                try:
                     _os.unlink(out_fn)
+                except FileNotFoundError:
+                    pass
     return failed_files
 
 

--- a/src/conda_package_handling/api.py
+++ b/src/conda_package_handling/api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools as _functools
 import os as _os
 import warnings as _warnings
+from contextlib import suppress as _suppress
 from glob import glob as _glob
 
 # expose these two exceptions as part of the API.  Everything else should feed into these.
@@ -77,9 +78,8 @@ def extract(fn, dest_dir=None, components=None, prefix=None):
             break
     else:
         raise ValueError(
-            "Didn't recognize extension for file '{}'.  Supported extensions are: {}".format(
-                fn, list(SUPPORTED_EXTENSIONS.keys())
-            )
+            f"Didn't recognize extension for file '{fn}'.  Supported extensions are: "
+            f"{list(SUPPORTED_EXTENSIONS.keys())}"
         )
 
 
@@ -116,9 +116,8 @@ def create(prefix, file_list, out_fn, out_folder=None, **kw):
                 raise err
     else:
         raise ValueError(
-            "Didn't recognize extension for file '{}'.  Supported extensions are: {}".format(
-                out_fn, list(SUPPORTED_EXTENSIONS.keys())
-            )
+            f"Didn't recognize extension for file '{out_fn}'.  Supported extensions are: "
+            f"{list(SUPPORTED_EXTENSIONS.keys())}"
         )
 
     return out
@@ -144,8 +143,8 @@ def _convert(
         return (
             fn,
             "",
-            "Input file %s doesn't have a supported extension (%s), skipping it"
-            % (fn, SUPPORTED_EXTENSIONS),
+            f"Input file {fn} doesn't have a supported extension ({SUPPORTED_EXTENSIONS}), "
+            "skipping it",
         )
     out_fn = str(_os.path.join(out_folder, basename + out_ext))
     errors = ""
@@ -215,10 +214,8 @@ def transmute(in_file, out_ext, out_folder=None, processes=1, **kw):
         for fn, out_fn, errors in executor.map(convert_f, flist):
             if errors:
                 failed_files[fn] = errors
-                try:
+                with _suppress(FileNotFoundError):
                     _os.unlink(out_fn)
-                except FileNotFoundError:
-                    pass
     return failed_files
 
 

--- a/src/conda_package_handling/cli.py
+++ b/src/conda_package_handling/cli.py
@@ -133,32 +133,33 @@ def main(args=None):
         args.out_folder = (
             os.path.abspath(os.path.normpath(os.path.expanduser(args.out_folder))) + os.sep
         )
-    if args.subcommand in ("extract", "x"):
-        if args.info:
-            api.extract(args.archive_path, args.dest, components="info", prefix=args.prefix)
-        else:
-            api.extract(args.archive_path, args.dest, prefix=args.prefix)
-    elif args.subcommand in ("create", "c"):
-        api.create(args.prefix, args.file_list, args.out_fn, args.out_folder)
-    elif args.subcommand in ("transmute", "t"):
-        failed_files = api.transmute(
-            args.in_file,
-            args.out_ext,
-            args.out_folder,
-            args.processes or 1,
-            force=args.force,
-            zstd_compress_level=args.zstd_compression_level,
-            zstd_compress_threads=args.zstd_compression_threads,
-        )
-        if failed_files:
-            print("failed files:")
-            pprint(failed_files)
-            sys.exit(1)
-    elif args.subcommand in ("list", "l"):
-        components = [
-            component.strip() for component in (args.components or "info,pkg").split(",")
-        ]
-        api.list_contents(args.archive_path, verbose=args.verbose, components=components)
+    match args.subcommand:
+        case "extract" | "x":
+            if args.info:
+                api.extract(args.archive_path, args.dest, components="info", prefix=args.prefix)
+            else:
+                api.extract(args.archive_path, args.dest, prefix=args.prefix)
+        case "create" | "c":
+            api.create(args.prefix, args.file_list, args.out_fn, args.out_folder)
+        case "transmute" | "t":
+            failed_files = api.transmute(
+                args.in_file,
+                args.out_ext,
+                args.out_folder,
+                args.processes or 1,
+                force=args.force,
+                zstd_compress_level=args.zstd_compression_level,
+                zstd_compress_threads=args.zstd_compression_threads,
+            )
+            if failed_files:
+                print("failed files:")
+                pprint(failed_files)
+                sys.exit(1)
+        case "list" | "l":
+            components = [
+                component.strip() for component in (args.components or "info,pkg").split(",")
+            ]
+            api.list_contents(args.archive_path, verbose=args.verbose, components=components)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/conda_package_handling/conda_fmt.py
+++ b/src/conda_package_handling/conda_fmt.py
@@ -11,8 +11,8 @@ import os
 import stat
 import tarfile
 import time
+from collections.abc import Callable
 from contextlib import closing
-from typing import Callable
 from zipfile import ZIP_STORED, ZipFile
 
 import zstandard
@@ -109,8 +109,9 @@ class CondaFormat_v2(AbstractBaseFormat):
             def tell(self):
                 return self.size
 
-        with ZipFile(conda_pkg_fn, "w", compression=ZIP_STORED) as conda_file, utils.tmp_chdir(
-            prefix
+        with (
+            ZipFile(conda_pkg_fn, "w", compression=ZIP_STORED) as conda_file,
+            utils.tmp_chdir(prefix),
         ):
             pkg_metadata = {"conda_pkg_format_version": CONDA_PACKAGE_FORMAT_VERSION}
             conda_file.writestr("metadata.json", json.dumps(pkg_metadata))
@@ -186,7 +187,7 @@ class CondaFormat_v2(AbstractBaseFormat):
                             f"{member.uname or member.uid}/{member.gname or member.gid} "
                             f"{member.size:10d} "
                         )
-                        line += "%d-%02d-%02d %02d:%02d:%02d " % time.localtime(member.mtime)[:6]
+                        line += time.strftime("%Y-%m-%d %H:%M:%S ", time.localtime(member.mtime))
                     lines[path] = line + path
                 if "pkg" in components and member.name == "info/paths.json":
                     data = json.loads(tar.extractfile(member).read().decode())

--- a/src/conda_package_handling/exceptions.py
+++ b/src/conda_package_handling/exceptions.py
@@ -6,8 +6,8 @@ class InvalidArchiveError(Exception):
 
     def __init__(self, fn, msg, *args, **kw):
         msg = (
-            "Error with archive %s.  You probably need to delete and re-download "
-            "or re-create this file.  Message was:\n\n%s" % (fn, msg)
+            f"Error with archive {fn}.  You probably need to delete and re-download "
+            f"or re-create this file.  Message was:\n\n{msg}"
         )
         self.errno = ENOENT
         super().__init__(msg)
@@ -21,7 +21,7 @@ class ArchiveCreationError(Exception):
 
 class CaseInsensitiveFileSystemError(InvalidArchiveError):
     def __init__(self, package_location, extract_location, **kwargs):
-        message = """
+        message = f"""
         Cannot extract package to a case-insensitive file system. Your install
         destination does not differentiate between upper and lowercase
         characters, and this breaks things. Try installing to a location that
@@ -29,8 +29,8 @@ class CaseInsensitiveFileSystemError(InvalidArchiveError):
         you install to a native Unix drive, or turn on case sensitivity for
         this (Windows) location?
 
-          package location: %(package_location)s
-          extract location: %(extract_location)s
+          package location: {package_location}
+          extract location: {extract_location}
         """
         self.package_location = package_location
         self.extract_location = extract_location
@@ -43,11 +43,10 @@ class ConversionError(Exception):
         self.mismatching_sizes = mismatching_sizes
         errors = ""
         if self.missing_files:
-            errors = "Missing files in converted package: %s\n" % self.missing_files
+            errors = f"Missing files in converted package: {self.missing_files}\n"
         errors = (
             errors
-            + "Mismatching sizes (corruption) in converted package: %s"  # noqa
-            % self.mismatching_sizes
+            + f"Mismatching sizes (corruption) in converted package: {self.mismatching_sizes}"
         )
 
         super().__init__(errors, *args, **kw)

--- a/src/conda_package_handling/streaming.py
+++ b/src/conda_package_handling/streaming.py
@@ -6,10 +6,10 @@ from __future__ import annotations
 
 import io
 import tarfile
+from collections.abc import Generator
 from contextlib import redirect_stdout
 from pathlib import Path
 from tarfile import TarError
-from typing import Generator
 from zipfile import BadZipFile
 
 from conda_package_streaming.extract import exceptions as cps_exceptions


### PR DESCRIPTION
## Summary

- Drop Python 3.8 and 3.9 support by raising project metadata and the conda recipe to Python 3.10+.
- Add Python 3.13 and 3.14 to the CI test matrix.
- Require `conda-package-streaming >=0.12.0` so the recipe tests pass on Python 3.14.
- Modernize a few code paths now that Python 3.10 is the minimum, including `match`/`case`, `collections.abc` generic imports, and f-strings.
- Update CI to setup-miniconda v4.0.1, install `conda-build` into base with `conda-build-version`, and keep using `conda build`.
- Add a news snippet for the support and dependency changes.

## Validation

- `ruff check --select UP --target-version py310 src tests`
- `ruff check src tests`
- `ruff format --check src tests`
- `python3 -m compileall -q src tests`
- `PYTHONPATH=src uv run --no-project --python /opt/homebrew/bin/python3 --with pytest --with pytest-mock --with bottle --with mock --with conda-package-streaming==0.12.0 --with zstandard --with requests python -m pytest -q -o addopts='' tests` (`40 passed, 1 skipped`)

## CI Notes

- The GitHub Actions test workflow runs package tests through `conda build`, using the recipe `test.commands` section.
- `conda-build` is installed into base via setup-miniconda so the base `conda` entry point can discover the `conda build` subcommand plugin while `test_env` remains the activated build environment.
- Earlier CI failures exposed the base-vs-active-env `conda-build` plugin scope and the older `conda-package-streaming` Python 3.14 incompatibility; both are addressed in this branch.