### PR TITLE
Add workflow concurrency limits

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   sphinx:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}


### PR DESCRIPTION
### Description

Add PR-aware concurrency groups to the documentation and test workflows so new commits cancel obsolete runs for the same pull request. Pushes to other refs remain isolated.

Part of conda/infrastructure#706

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Codex

### Checklist - did you ...

- [x] ~~Add a file to the news directory for the next release's release notes~~
- [x] ~~Add or update necessary tests~~
- [x] ~~Add or update outdated documentation~~
