### PR TITLE
Make custom exceptions pickle-safe

### DIFF
--- a/news/348-pickle-safe-exceptions
+++ b/news/348-pickle-safe-exceptions
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Preserve custom exception types and state when errors cross process boundaries. (#348)
+* Preserve custom exception types and state when errors cross process boundaries by making them pickle-safe. (#348)
 
 ### Deprecations
 

--- a/news/348-pickle-safe-exceptions
+++ b/news/348-pickle-safe-exceptions
@@ -1,0 +1,19 @@
+### Enhancements
+
+* <news item>
+
+### Bug fixes
+
+* Preserve custom exception types and state when errors cross process boundaries. (#348)
+
+### Deprecations
+
+* <news item>
+
+### Docs
+
+* <news item>
+
+### Other
+
+* <news item>

--- a/src/conda_package_handling/exceptions.py
+++ b/src/conda_package_handling/exceptions.py
@@ -5,12 +5,16 @@ class InvalidArchiveError(Exception):
     """Raised when libarchive can't open a file"""
 
     def __init__(self, fn, msg, *args, **kw):
+        self._pickle_args = (fn, msg, *args)
         msg = (
             f"Error with archive {fn}.  You probably need to delete and re-download "
             f"or re-create this file.  Message was:\n\n{msg}"
         )
         self.errno = ENOENT
         super().__init__(msg)
+
+    def __reduce__(self):
+        return type(self), self._pickle_args, {**self.__dict__, "args": self.args}
 
 
 class ArchiveCreationError(Exception):
@@ -35,10 +39,12 @@ class CaseInsensitiveFileSystemError(InvalidArchiveError):
         self.package_location = package_location
         self.extract_location = extract_location
         super().__init__(package_location, message, **kwargs)
+        self._pickle_args = (package_location, extract_location)
 
 
 class ConversionError(Exception):
     def __init__(self, missing_files, mismatching_sizes, *args, **kw):
+        self._pickle_args = (missing_files, mismatching_sizes, *args)
         self.missing_files = missing_files
         self.mismatching_sizes = mismatching_sizes
         errors = ""
@@ -50,3 +56,6 @@ class ConversionError(Exception):
         )
 
         super().__init__(errors, *args, **kw)
+
+    def __reduce__(self):
+        return type(self), self._pickle_args, {**self.__dict__, "args": self.args}

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,36 @@
+import pickle
+
+import pytest
+
+from conda_package_handling.exceptions import (
+    CaseInsensitiveFileSystemError,
+    ConversionError,
+    InvalidArchiveError,
+)
+
+
+@pytest.mark.parametrize(
+    ("error_type", "constructor_args"),
+    (
+        (InvalidArchiveError, ("archive.conda", "invalid archive")),
+        (CaseInsensitiveFileSystemError, ("archive.conda", "destination")),
+        (ConversionError, (["missing"], ["mismatched"], "extra context")),
+    ),
+    ids=(
+        "InvalidArchiveError",
+        "CaseInsensitiveFileSystemError",
+        "ConversionError",
+    ),
+)
+def test_exception_pickle_round_trip(mocker, error_type, constructor_args):
+    error = error_type(*constructor_args)
+    error.extra_state = {"preserved": True}
+    init = mocker.spy(error_type, "__init__")
+
+    restored = pickle.loads(pickle.dumps(error))
+
+    init.assert_called_once_with(restored, *constructor_args)
+    assert type(restored) is type(error)
+    assert restored.args == error.args
+    assert str(restored) == str(error)
+    assert vars(restored) == vars(error)


### PR DESCRIPTION
### Description

Fixes #348.

Preserve the type, arguments, and instance state of `InvalidArchiveError`, `CaseInsensitiveFileSystemError`, and `ConversionError` during unpickling. Store the original constructor arguments for each exception so unpickling reconstructs it through its public constructor, then restore its current arguments and instance state.

This lets process-pool consumers receive the original extraction error instead of losing it to a result-deserialization failure. The defensive conda-side handling is conda/conda#16555.

### Checklist - did you ...

- [x] Add a file to the `news` directory ([using the template](https://github.com/conda/conda-package-handling/blob/main/news/TEMPLATE)) for the next release's release notes?
- [x] Add / update necessary tests?
- [x] ~Add / update outdated documentation?~ Not applicable.