### PR TITLE
Pass matrix Python version to conda-build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
       # conda setup requires this special shell
       shell: bash -l {0}
       run: |
-        conda-build -c conda -c conda-forge conda.recipe
+        conda-build -c conda -c conda-forge --python "${{ matrix.python-version }}" conda.recipe
 
 # TODO: Re-enable codecov when we figure out how to grab coverage from the conda build
 #       environment

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -20,7 +20,7 @@ build:
 
 requirements:
   host:
-    - python >=3.10
+    - python
     - pip
     - wheel
     - flit

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - wheel
     - flit
   run:
-    - python >=3.10
+    - python
     - zstandard >=0.15
     - conda-package-streaming >=0.13.0
     - requests


### PR DESCRIPTION
### Description

The workflow configures the setup environment with the matrix Python version, but `conda-build` resolves the recipe's `python >=3.10` independently.

This is visible in the logs for #329. The [Python 3.10 job](https://github.com/conda/conda-package-handling/actions/runs/32181434576/job/95855145844) and [Python 3.13 job](https://github.com/conda/conda-package-handling/actions/runs/32181434576/job/95855146020) both built `conda-package-handling-2.5.0-py314_0.conda` and installed Python 3.14.6.

Make the recipe's host and run Python requirements variant-driven, then pass the matrix value to `conda-build --python`. Conda-build emits a matching per-minor runtime pin, so each job builds and tests the advertised Python version. The supported floor remains Python 3.10 in the project metadata and matrix.

### Checklist - did you ...

- [x] ~Add a file to the `news` directory for the next release's release notes?~
- [x] ~Add / update necessary tests?~
- [x] ~Add / update outdated documentation?~
